### PR TITLE
add seaport mainnet & joepegs addresses

### DIFF
--- a/Marketplace-Contracts.md
+++ b/Marketplace-Contracts.md
@@ -3,3 +3,12 @@ NFT Trade (via Chainport)
 
 Kalao Token (KLO)
 0xb27c8941a7df8958a1778c0259f76d1f8b711c35
+
+Joepegs Mainnet
+0xaE079eDA901F7727D0715aff8f82BA8295719977
+
+Joepegs Testnet (FUJI)
+0x04e290BE5163Ad5c92109Eb4733C45A2dF110d44
+
+Opensea Mainnet (Seaport)
+0x00000000006c3852cbef3e08e8df289169ede581


### PR DESCRIPTION
This adds the mainnet seaport contract address & both joepegs addresses 